### PR TITLE
Site navigation for mobile devices

### DIFF
--- a/source/javascripts/all_nosearch.js
+++ b/source/javascripts/all_nosearch.js
@@ -1,6 +1,7 @@
 //= require ./lib/_energize
 //= require ./app/_toc
 //= require ./app/_lang
+//= require ./app/_header
 
 $(function() {
   loadToc($('#toc'), '.toc-link', '.toc-list-h2', 10);

--- a/source/javascripts/app/_header.js
+++ b/source/javascripts/app/_header.js
@@ -3,6 +3,8 @@
 
   window.onload = function(){
 
+    // open navigation drawer on mobile devices
+
     var navPanel = document.getElementById('site-nav');
     var navButton = document.getElementById('site-nav-toggle');
 
@@ -12,5 +14,25 @@
       });
     }
 
+    // hide fixed navigation when scrolling to make more room for text
+
+    var isMobile = window.matchMedia('(max-width: 730px)');
+
+    var layout = document.body;
+    var prevScrollpos = window.pageYOffset;
+
+    if (isMobile.matches) {
+      window.onscroll = function() {
+        var currentScrollPos = window.pageYOffset;
+        if (prevScrollpos > currentScrollPos) {
+          layout.classList.remove('shrink');
+        } else {
+          layout.classList.add('shrink');
+        }
+        prevScrollpos = currentScrollPos;
+      }
+    }
+
   };
+
 })();

--- a/source/javascripts/app/_header.js
+++ b/source/javascripts/app/_header.js
@@ -1,0 +1,16 @@
+;(function () {
+  'use strict';
+
+  window.onload = function(){
+
+    var navPanel = document.getElementById('site-nav');
+    var navButton = document.getElementById('site-nav-toggle');
+
+    if(navButton) {
+      navButton.addEventListener('click', function(e) {
+        navPanel.classList.toggle('open');
+      });
+    }
+
+  };
+})();

--- a/source/javascripts/app/_header.js
+++ b/source/javascripts/app/_header.js
@@ -16,7 +16,7 @@
 
     // hide fixed navigation when scrolling to make more room for text
 
-    var isMobile = window.matchMedia('(max-width: 730px)');
+    var isMobile = window.matchMedia('(max-width: 930px)');
 
     var layout = document.body;
     var prevScrollpos = window.pageYOffset;

--- a/source/javascripts/app/_header.js
+++ b/source/javascripts/app/_header.js
@@ -5,7 +5,7 @@
 
     // open navigation drawer on mobile devices
 
-    var navPanel = document.getElementById('site-nav');
+    var navPanel = document.getElementById('site-header');
     var navButton = document.getElementById('site-nav-toggle');
 
     if(navButton) {

--- a/source/javascripts/app/_search.js
+++ b/source/javascripts/app/_search.js
@@ -79,7 +79,7 @@
         highlight.call(searchInput);
       } else {
         searchResults.html('<li></li>');
-        $('.search-results li').text('No Results Found for "' + searchInput.value + '"');
+        $('.search-results li').text('No results found for "' + searchInput.value + '"').addClass("empty");
       }
     } else {
       unhighlight();

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -35,6 +35,7 @@ under the License.
     <style>
       <%= Rouge::Themes::MonokaiSublime.render(:scope => '.highlight') %>
     </style>
+    <%= stylesheet_link_tag :header, media: :screen %>
     <%= stylesheet_link_tag :screen, media: :screen %>
     <%= stylesheet_link_tag :print, media: :print %>
     <% if current_page.data.search %>
@@ -47,29 +48,29 @@ under the License.
 
   <body class="<%= page_classes %>" data-languages="<%=h language_tabs.map{ |lang| lang.is_a?(Hash) ? lang.keys.first : lang }.to_json %>">
 
-    <header class="site-header">
+     <header class="site-header">
       <a href="/" class="site-logo">
         <%= image_tag "logo.svg" %>
       </a>
       <nav class="site-nav <%= page_classes %>">
-        <div>
-          <a href="https://developer.hushmesh.com" class="nav-active">Documentation</a>
-          <a href="https://developer.hushmesh.com/relying-party-registration">Manage Apps</a>
-          <a href="https://developer.hushmesh.com/token-viewer">View Token Structure</a>
+        <div class="nav-portal">
+          <a href="https://developer.hushmesh.com" class="nav-active"><span class="full">Documentation</span> <span class="short">Docs</span></a>
+          <a href="https://developer.hushmesh.com/relying-party-registration"><span class="full">Manage Apps</span> <span class="short">Apps</span></a>
+          <a href="https://developer.hushmesh.com/token-viewer"><span class="full">View Token Structure</span> <span class="short">Tokens</span></a>
         </div>
-        <div class="nav-right">
+        <aside class="nav-external">
           <a href="https://www.npmjs.com/package/@hushmesh/meshlib" target="_blank" class="link-external">meshlib Library</a>
           <a href="https://www.hushmesh.com" target="_blank" class="link-external">Hushmesh.com</a>
-        </div>
+        </aside>
       </nav>
     </header>
 
     <a href="#" id="nav-button">
       <span>
-        NAV
         <%= image_tag('navbar.png') %>
       </span>
     </a>
+
     <div class="toc-wrapper">
       <% if language_tabs.any? %>
         <div class="lang-selector">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -86,7 +86,7 @@ under the License.
       <% end %>
       <% if current_page.data.search %>
         <div class="search">
-          <input type="text" class="search" id="input-search" placeholder="Search">
+          <input type="search" class="search" id="input-search" placeholder="Search">
         </div>
         <ul class="search-results"></ul>
       <% end %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -48,11 +48,11 @@ under the License.
 
   <body class="<%= page_classes %>" data-languages="<%=h language_tabs.map{ |lang| lang.is_a?(Hash) ? lang.keys.first : lang }.to_json %>">
 
-     <header class="site-header">
+     <header class="site-header" id="site-header">
       <a href="/" class="site-logo">
         <%= image_tag "logo.svg" %>
       </a>
-      <nav class="site-nav <%= page_classes %>" id="site-nav">
+      <nav class="site-nav <%= page_classes %>">
         <div class="nav-portal">
           <a href="https://developer.hushmesh.com" class="nav-active">Documentation</a>
           <a href="https://developer.hushmesh.com/relying-party-registration">Manage Apps</a>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -52,24 +52,25 @@ under the License.
       <a href="/" class="site-logo">
         <%= image_tag "logo.svg" %>
       </a>
-      <nav class="site-nav <%= page_classes %>">
+      <nav class="site-nav <%= page_classes %>" id="site-nav">
         <div class="nav-portal">
-          <a href="https://developer.hushmesh.com" class="nav-active"><span class="full">Documentation</span> <span class="short">Docs</span></a>
-          <a href="https://developer.hushmesh.com/relying-party-registration"><span class="full">Manage Apps</span> <span class="short">Apps</span></a>
-          <a href="https://developer.hushmesh.com/token-viewer"><span class="full">View Token Structure</span> <span class="short">Tokens</span></a>
+          <a href="https://developer.hushmesh.com" class="nav-active">Documentation</a>
+          <a href="https://developer.hushmesh.com/relying-party-registration">Manage Apps</a>
+          <a href="https://developer.hushmesh.com/token-viewer">View Token Structure</a>
         </div>
         <aside class="nav-external">
           <a href="https://www.npmjs.com/package/@hushmesh/meshlib" target="_blank" class="link-external">meshlib Library</a>
           <a href="https://www.hushmesh.com" target="_blank" class="link-external">Hushmesh.com</a>
         </aside>
+        <button class="site-nav-toggle" id="site-nav-toggle" title="Show site navigation"><span></span></button>
       </nav>
     </header>
 
-    <a href="#" id="nav-button">
+    <button id="nav-button" title="Show and search table of contents">
       <span>
-        <%= image_tag('navbar.png') %>
+        Search
       </span>
-    </a>
+    </button>
 
     <div class="toc-wrapper">
       <% if language_tabs.any? %>

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -64,7 +64,7 @@ $lang-select-pressed-text: #fff !default; // color of language tab text when mou
 // SIZES
 ////////////////////
 $nav-width: 200px !default; // width of the navbar
-$nav-width-mobile: 170px !default; // width of the expanded ToC navbar on mobile
+$nav-width-mobile: 200px !default; // width of the expanded ToC navbar on mobile
 $top-nav-height: 60px;
 $examples-width: 50% !default; // portion of the screen taken up by code examples
 $logo-margin: 0px !default; // margin below logo

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -64,7 +64,7 @@ $lang-select-pressed-text: #fff !default; // color of language tab text when mou
 // SIZES
 ////////////////////
 $nav-width: 200px !default; // width of the navbar
-$nav-width-mobile: 200px !default; // width of the expanded ToC navbar on mobile
+$nav-width-mobile: 100% !default; // width of the expanded ToC navbar on mobile
 $top-nav-height: 60px;
 $examples-width: 50% !default; // portion of the screen taken up by code examples
 $logo-margin: 0px !default; // margin below logo

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -64,6 +64,7 @@ $lang-select-pressed-text: #fff !default; // color of language tab text when mou
 // SIZES
 ////////////////////
 $nav-width: 200px !default; // width of the navbar
+$nav-width-mobile: 170px !default; // width of the expanded ToC navbar on mobile
 $top-nav-height: 60px;
 $examples-width: 50% !default; // portion of the screen taken up by code examples
 $logo-margin: 0px !default; // margin below logo
@@ -124,21 +125,3 @@ $main-embossed-text-shadow: 0px 1px 0px #fff !default;
     word-break: break-all;
     hyphens: auto;
 }
-
-
-//////////////////////////////////////////////////////////////////////////
-// CUSTOM OVERWRITE
-//////////////////////////////////////////////////////////////////////////
-
-// SIZES
-
-
-/*
-// BACKGROUND COLORS
-$color-red: #316FEB; // not red anymore, but keeping it to avoid many changes
-$aside-notice-bg: #ddd;
-$separator-color: #efefef;
-
-$color-header-grey: #4b4b4c;
-$title-color: $color-header-grey;
-$paragraph-color: #2B2B32;*/

--- a/source/stylesheets/header.css.scss
+++ b/source/stylesheets/header.css.scss
@@ -8,10 +8,12 @@
   padding: 10px 32px 10px;
   background-color: white;
   position: fixed;
+  top: 0;
   z-index: 102;
   width: 100%;
   height: $top-nav-height;
   box-shadow: 0 2px 10px -6px rgba(0,0,0,.2);
+  transition: top .3s;
 }
 
 .site-logo {
@@ -128,6 +130,16 @@ a.link-external:after {
 }
 
 @media (max-width: $phone-width) {
+
+  .shrink  {
+    .site-header {
+      top: -$top-nav-height;
+    }
+
+    #nav-button {
+      bottom: -51px;
+    }
+  }
 
   #site-nav-toggle {
     display: block;

--- a/source/stylesheets/header.css.scss
+++ b/source/stylesheets/header.css.scss
@@ -127,10 +127,6 @@ a.link-external:after {
 
 @media (max-width: $tablet-width) {
 
-}
-
-@media (max-width: $phone-width) {
-
   .shrink  {
     .site-header {
       top: -$top-nav-height;

--- a/source/stylesheets/header.css.scss
+++ b/source/stylesheets/header.css.scss
@@ -44,23 +44,31 @@
     line-height: 54px;
     display: inline-block;
 
-    .short {
-      display: none;
-    }
 
     &:link,
     &:visited,
     &:active {
       color: $primary-text;
     }
+
     &:hover {
       color: $primary;
     }
+
     &.nav-active {
       color: $primary;
     }
-    &.link-external:after {
-      top: 23px;
+
+    &.link-external {
+      margin-right: 1em;
+
+      &:last-child {
+        margin-right: 0;
+      }
+
+      &:after {
+        top: 23px;
+      }
     }
   }
 
@@ -123,6 +131,10 @@ a.link-external:after {
   .site-logo {
     width: 186px;
     margin-left: -2px;
+  }
+
+  .site-nav a {
+    margin-right: 1em;
   }
 }
 

--- a/source/stylesheets/header.css.scss
+++ b/source/stylesheets/header.css.scss
@@ -41,6 +41,10 @@
     line-height: 54px;
     display: inline-block;
 
+    .short {
+      display: none;
+    }
+
     &:link,
     &:visited,
     &:active {
@@ -65,26 +69,46 @@
   }
 }
 
+.site-nav-toggle {
+  display: none;
+
+  height: $top-nav-height;
+  background: none;
+  border: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  left: 0;
+
+  &:focus {
+    border: none;
+    outline: none;
+  }
+
+  span {
+    right: -40px;
+    bottom: -40px;
+    transition: right .1s ease-in, bottom .1s ease-in, box-shadow .3s ease-in .4s;
+  }
+}
+
 a.link-external {
   padding-right: 8px;
-  position: relative;
   display: inline-block;
 }
 
 a.link-external:after {
+  display: inline-block;
   content: '\2192';
   font-size: 15px;
   font-weight: 300;
-  position: absolute;
-  left: 100%;
-  top: 4px;
   width: 10px;
   height: 8px;
   overflow: hidden;
   text-align: right;
   line-height: 6px;
   text-indent: -11px;
-  margin: 0 0 0 -5px;
+  margin: 0 0 0 5px;
   transform: rotate(-45deg);
 }
 
@@ -105,10 +129,110 @@ a.link-external:after {
 
 @media (max-width: $phone-width) {
 
-
-  .site-logo img {
-    height: 32px;
-    margin: 6px 0 0 3px;
+  #site-nav-toggle {
+    display: block;
   }
+
+  .site-logo {
+    width: auto;
+
+    img {
+      height: 32px;
+      margin: 6px 0 0 3px;
+    }
+  }
+
+  .site-nav {
+    transition: all 0.3s ease-in-out;
+
+    &:not(.open) {
+      position: absolute;
+      right: 0;
+      padding-right: 16px;
+      text-align: right;
+      width: 100%;
+      display: block;
+
+      a:not(.nav-active) {
+        display: none;
+      }
+
+      .nav-active {
+        margin-right: 4px;
+        line-height: 58px;
+        display: inline-block;
+
+        &:after {
+          content: "";
+          display: inline;
+          border-width: 5px;
+          border-style: solid;
+          border-left-color: transparent;
+          border-right-color: transparent;
+          border-bottom-color: transparent;
+
+          position: relative;
+          top: 12px;
+          left: 6px;
+        }
+      }
+    }
+
+    &.open {
+      justify-content: space-between;
+      align-items: stretch;
+      flex-direction: column;
+      margin-top: 0;
+      position: fixed;
+      z-index: 101;
+      top: $top-nav-height;
+      bottom: 0;
+      background-color: white;
+      padding: 16px 0;
+
+      right: 0;
+      width: 100%;
+      background-color: white;
+
+      a {
+        display: block;
+        padding: $nav-v-padding $main-padding;
+        height: auto;
+        line-height: 1.35;
+        margin: 0;
+      }
+
+      .site-nav-toggle {
+        color: transparent;
+        top: -$top-nav-height;
+        left: auto;
+
+        span {
+          position: absolute;
+          top: calc(100vh - 67px);
+          right: 16px;
+          border-radius: 50%;
+          width: 51px;
+          height: 51px;
+          box-shadow: 0 8px 16px -4px rgba(#426a86, 40%);
+          background: white;
+        }
+
+        span:before {
+          content: "×";
+          font-size: 24px;
+          opacity: 1;
+          color: $primary;
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          line-height: 49px;
+        }
+      }
+    }
+  }
+
 }
 

--- a/source/stylesheets/header.css.scss
+++ b/source/stylesheets/header.css.scss
@@ -105,5 +105,10 @@ a.link-external:after {
 
 @media (max-width: $phone-width) {
 
+
+  .site-logo img {
+    height: 32px;
+    margin: 6px 0 0 3px;
+  }
 }
 

--- a/source/stylesheets/header.css.scss
+++ b/source/stylesheets/header.css.scss
@@ -1,0 +1,109 @@
+@charset "utf-8";
+@import 'variables';
+
+.site-header {
+  @extend %default-font;
+  -webkit-text-size-adjust: none; /* Never autoresize text */
+  box-sizing: border-box;
+  padding: 10px 32px 10px;
+  background-color: white;
+  position: fixed;
+  z-index: 102;
+  width: 100%;
+  height: $top-nav-height;
+  box-shadow: 0 2px 10px -6px rgba(0,0,0,.2);
+}
+
+.site-logo {
+  display: block;
+  float: left;
+  width: 264px;
+  margin: -1px 0 0 -8px;
+
+  img {
+    height: 36px;
+    display: block;
+    margin: 2px 0 0;
+  }
+}
+
+.site-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: -10px;
+
+  a {
+    color: $primary-text;
+    margin-right: 2em;
+    text-decoration: none;
+    height: 60px;
+    line-height: 54px;
+    display: inline-block;
+
+    &:link,
+    &:visited,
+    &:active {
+      color: $primary-text;
+    }
+    &:hover {
+      color: $primary;
+    }
+    &.nav-active {
+      color: $primary;
+    }
+    &.link-external:after {
+      top: 23px;
+    }
+  }
+
+  &.index {
+    a.link-index {
+      color: #474746;
+      cursor: default;
+    }
+  }
+}
+
+a.link-external {
+  padding-right: 8px;
+  position: relative;
+  display: inline-block;
+}
+
+a.link-external:after {
+  content: '\2192';
+  font-size: 15px;
+  font-weight: 300;
+  position: absolute;
+  left: 100%;
+  top: 4px;
+  width: 10px;
+  height: 8px;
+  overflow: hidden;
+  text-align: right;
+  line-height: 6px;
+  text-indent: -11px;
+  margin: 0 0 0 -5px;
+  transform: rotate(-45deg);
+}
+
+@media (max-width: 1100px) {
+  .site-header {
+    padding: 10px 16px 10px;
+  }
+
+  .site-logo {
+    width: 186px;
+    margin-left: -2px;
+  }
+}
+
+@media (max-width: $tablet-width) {
+
+}
+
+@media (max-width: $phone-width) {
+
+}
+

--- a/source/stylesheets/header.css.scss
+++ b/source/stylesheets/header.css.scss
@@ -3,7 +3,8 @@
 
 .site-header {
   @extend %default-font;
-  -webkit-text-size-adjust: none; /* Never autoresize text */
+  -webkit-font-smoothing: auto;
+  -webkit-text-size-adjust: none;
   box-sizing: border-box;
   padding: 10px 32px 10px;
   background-color: white;

--- a/source/stylesheets/header.css.scss
+++ b/source/stylesheets/header.css.scss
@@ -230,8 +230,8 @@ a.link-external:after {
 
         span {
           position: absolute;
-          top: calc(100vh - 67px);
-          right: 16px;
+          top: 8px;
+          right: 8px;
           border-radius: 50%;
           width: 51px;
           height: 51px;

--- a/source/stylesheets/header.css.scss
+++ b/source/stylesheets/header.css.scss
@@ -15,6 +15,13 @@
   height: $top-nav-height;
   box-shadow: 0 2px 10px -6px rgba(0,0,0,.2);
   transition: top .3s;
+
+  &.open {
+    background: white;
+    height: 100vh;
+    overflow: hidden;
+    overflow-y: auto;
+  }
 }
 
 .site-logo {
@@ -72,11 +79,9 @@
     }
   }
 
-  &.index {
-    a.link-index {
-      color: #474746;
-      cursor: default;
-    }
+  &.index a.link-index {
+    color: #474746;
+    cursor: default;
   }
 }
 
@@ -141,7 +146,7 @@ a.link-external:after {
 @media (max-width: $tablet-width) {
 
   .shrink  {
-    .site-header {
+    .site-header:not(.open) {
       top: -$top-nav-height;
     }
 
@@ -166,7 +171,7 @@ a.link-external:after {
   .site-nav {
     transition: all 0.3s ease-in-out;
 
-    &:not(.open) {
+    .site-header:not(.open) & {
       position: absolute;
       right: 0;
       padding-right: 16px;
@@ -199,7 +204,7 @@ a.link-external:after {
       }
     }
 
-    &.open {
+    .site-header.open & {
       justify-content: space-between;
       align-items: stretch;
       flex-direction: column;
@@ -208,12 +213,10 @@ a.link-external:after {
       z-index: 101;
       top: $top-nav-height;
       bottom: 0;
-      background-color: white;
       padding: 16px 0;
 
       right: 0;
       width: 100%;
-      background-color: white;
 
       a {
         display: block;

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -698,9 +698,8 @@ html, body {
     }
   }
 
-}
 
-@media (max-width: $phone-width) {
+
   .dark-box {
     display: none;
   }

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -126,11 +126,16 @@ html, body {
       border-radius: 2px;
       margin-top: 0px;
       border-top: 2px solid;
-      padding: 16px 0 0;
+      padding: 16px 0;
     }
 
     li {
       line-height: 1.35;
+    }
+
+    .empty {
+      padding: $nav-v-padding $nav-padding;
+      color: $secondary-text;
     }
 
     a {
@@ -672,6 +677,29 @@ html, body {
     }
   }
 
+  .content {
+    h1 {
+      font-size: 32px;
+      padding: 32px 20px 0 54px;
+    }
+
+    h2 {
+      font-size: 20px;
+      font-weight: 500;
+      padding-bottom: 1em;
+      padding-top: 32px;
+      padding-right: 16px;
+    }
+
+    & > p {
+      padding-right: 24px;
+    }
+
+    blockquote > p {
+      margin: 0;
+    }
+  }
+
   .page-wrapper {
     margin-left: 0;
   }
@@ -681,7 +709,7 @@ html, body {
   }
 
   .toc-wrapper .search-results.visible {
-    height: 60%;
+    height: 40%;
   }
 
   .toc-link,
@@ -697,8 +725,6 @@ html, body {
       left: 26px;
     }
   }
-
-
 
   .dark-box {
     display: none;

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -46,7 +46,7 @@ html, body {
 }
 
 .toc-wrapper {
-  transition: left 0.3s ease-in-out;
+  transition: all .3s ease-in-out;
 
   overflow-y: auto;
   overflow-x: hidden;
@@ -82,10 +82,10 @@ html, body {
       background: $nav-bg;
       border-width: 0;
       box-shadow: 0 1px 0 $search-box-border-color;
-      padding: 8px 0 10px 24px;
+      padding: 8px 0 10px $main-padding;
       box-sizing: border-box;
       margin: $nav-padding ($nav-padding - 4) 0 ($nav-padding - 4);
-      width: $nav-width - ($nav-padding*2);
+      width: 90%;
       outline: none;
       color: $nav-text;
       font-size: 14px;;
@@ -126,17 +126,18 @@ html, body {
       border-radius: 2px;
       margin-top: 0px;
       border-top: 2px solid;
+      padding: 16px 0 0;
     }
 
     li {
-      margin: 1em $nav-padding;
       line-height: 1.35;
-      font-size: 14px;
     }
 
     a {
+      padding: $nav-v-padding $nav-padding;
       color: $nav-text;
       text-decoration: none;
+      display: block;
 
       &:hover {
         color: $primary;
@@ -221,25 +222,58 @@ html, body {
 
 // button to show navigation on mobile devices
 #nav-button {
-  span {
-    display: block;
-    padding: 22px 15px 22px 24px;
-    background: white;
-  }
   display: none;
   position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 102;
+  bottom: 0;
+  right: 0;
+  z-index: 101;
 
-  img {
-    height: 16px;
-    vertical-align: bottom;
-    transform: rotate(90deg);
+  width: 100%;
+  padding: 16px 15px 18px 24px;
+  background: rgba(white, 95%);
+  backdrop-filter: blur(10px);
+  border: none;
+  color: $secondary-text;
+
+  text-align: left;
+  transition: right .1s ease-in, bottom .1s ease-in, box-shadow .3s ease-in .4s;
+
+  &:focus {
+    border: none;
+    outline: none;
+  }
+
+  span {
+    display: block;
+    position: relative;
+    padding-left: 20px;
+
+    &:before {
+      position: absolute;
+      top: 2px;
+      left: 0;
+      opacity: .3;
+      @extend %icon-search;
+      transition: color .3s ease-in .1s;
+    }
   }
 
   &.open {
-    padding: 0 100% 0 0; // click on all area to hide ToC
+    width: 51px;
+    color: transparent;
+    border-radius: 50%;
+    right: 16px;
+    bottom: 16px;
+    box-shadow: 0 8px 16px -4px rgba(#426a86, 20%);
+
+    span:before {
+      content: "×";
+      font-size: 24px;
+      opacity: 1;
+      color: $primary;
+      top: -6px;
+      left: -5px;
+    }
   }
 }
 
@@ -606,14 +640,10 @@ html, body {
   .toc-wrapper {
     width: $nav-width-mobile;
     padding: 60px 0px 40px;
-
-    & > .search input {
-      width: 146px;
-    }
   }
 
   .page-wrapper {
-    margin-left: 170px;
+    margin-left: $nav-width;
   }
 
   .content .contact {
@@ -629,11 +659,16 @@ html, body {
 
 @media (max-width: $tablet-width) {
   .toc-wrapper {
-    left: -$nav-width;
+    left: 0;
+    top: 200px;
+    opacity: 0;
+    z-index: 9;
 
     &.open {
-      left: 0;
-      box-shadow: 10px 0 10px -6px rgba(0, 0, 0, 0.1);
+      top: 0;
+      opacity: 1;
+      z-index: 11;
+      //box-shadow: 10px 0 10px -6px rgba(0, 0, 0, 0.1);
     }
   }
 
@@ -645,10 +680,24 @@ html, body {
     display: block;
   }
 
-  .toc-link {
-    padding-top: 0.3em;
-    padding-bottom: 0.3em;
+  .toc-wrapper .search-results.visible {
+    height: 60%;
   }
+
+  .toc-link,
+  .toc-wrapper .search-results a {
+    padding: $nav-v-padding $main-padding;
+  }
+
+  .toc-wrapper > .search {
+    input {
+      padding-left: 40px;
+    }
+    &:before {
+      left: 26px;
+    }
+  }
+
 }
 
 @media (max-width: $phone-width) {

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -223,37 +223,23 @@ html, body {
 #nav-button {
   span {
     display: block;
-    padding: 17px 20px 20px;
-    border-radius: 0 4px 0 0;
-    background: rgba(255, 255, 255, .8);
-    backdrop-filter: blur(10px);
+    padding: 22px 15px 22px 24px;
+    background: white;
   }
-  padding: 2em 1.5em 0 0; // increase touch size area
   display: none;
   position: fixed;
-  bottom: 0;
+  top: 0;
   left: 0;
-  z-index: 100;
+  z-index: 102;
 
   img {
-    height: 24px;
+    height: 16px;
     vertical-align: bottom;
     transform: rotate(90deg);
   }
 
-  transition: left 0.3s ease-in-out;
-
-  &:hover { opacity: 1; }
   &.open {
-    left: $nav-width-mobile;
-    padding: 100vh 100% 0 0; // click on all area to hide ToC
-    background: rgba(255, 255, 255, .8);
-    backdrop-filter: blur(10px);
-
-    span {
-      background: none;
-      backdrop-filter: none;
-    }
+    padding: 0 100% 0 0; // click on all area to hide ToC
   }
 }
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -638,7 +638,6 @@ html, body {
 
 @media (max-width: 1100px) {
   .toc-wrapper {
-    width: $nav-width-mobile;
     padding: 60px 0px 40px;
   }
 
@@ -661,6 +660,7 @@ html, body {
   .toc-wrapper {
     left: 0;
     top: 200px;
+    width: $nav-width-mobile;
     opacity: 0;
     z-index: 9;
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -34,86 +34,6 @@ html, body {
   -webkit-text-size-adjust: none; /* Never autoresize text */
 }
 
-.site-header {
-  box-sizing: border-box;
-  padding: 10px 32px 10px;
-  background-color: white;
-  position: fixed;
-  z-index: 100;
-  width: 100%;
-  height: $top-nav-height;
-  box-shadow: 0 2px 10px -6px rgba(0,0,0,.2);
-}
-
-.site-logo {
-  display: block;
-  float: left;
-  width: 264px;
-  margin: -1px 0 0 -8px;
-
-  img {
-    height: 36px;
-    display: block;
-    margin: 2px 0 0;
-  }
-}
-
-.site-nav {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: -10px;
-
-  a {
-    color: $primary-text;
-    margin-right: 2em;
-    text-decoration: none;
-    height: 60px;
-    line-height: 54px;
-    display: inline-block;
-
-    &:hover {
-      color: $primary;
-    }
-    &.nav-active {
-      color: $primary;
-    }
-    &.link-external:after {
-      top: 23px;
-    }
-  }
-
-  &.index {
-    a.link-index {
-      color: #474746;
-      cursor: default;
-    }
-  }
-}
-
-a.link-external {
-  padding-right: 8px;
-  position: relative;
-  display: inline-block;
-}
-
-a.link-external:after {
-  content: '\2192';
-  font-size: 15px;
-  font-weight: 300;
-  position: absolute;
-  left: 100%;
-  top: 4px;
-  width: 10px;
-  height: 8px;
-  overflow: hidden;
-  text-align: right;
-  line-height: 6px;
-  text-indent: -11px;
-  margin: 0 0 0 -5px;
-  transform: rotate(-45deg);
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // TABLE OF CONTENTS
 ////////////////////////////////////////////////////////////////////////////////
@@ -131,7 +51,7 @@ a.link-external:after {
   overflow-y: auto;
   overflow-x: hidden;
   position: fixed;
-  z-index: 30;
+  z-index: 101;
   top: 0;
   left: 0;
   bottom: 0;
@@ -303,33 +223,38 @@ a.link-external:after {
 #nav-button {
   span {
     display: block;
-    $side-pad: $main-padding / 2 - 8px;
-    padding: $side-pad $side-pad $side-pad;
-    background-color: rgba($main-bg, 0.7);
-    transform-origin: 0 0;
-    transform: rotate(-90deg) translate(-100%, 0);
-    border-radius: 0 0 0 5px;
+    padding: 17px 20px 20px;
+    border-radius: 0 4px 0 0;
+    background: rgba(255, 255, 255, .8);
+    backdrop-filter: blur(10px);
   }
-  padding: 0 1.5em 5em 0; // increase touch size area
+  padding: 2em 1.5em 0 0; // increase touch size area
   display: none;
   position: fixed;
-  top: 0;
+  bottom: 0;
   left: 0;
   z-index: 100;
-  color: #000;
-  text-decoration: none;
-  font-weight: bold;
-  opacity: 0.7;
-  line-height: 16px;
+
   img {
-    height: 16px;
+    height: 24px;
     vertical-align: bottom;
+    transform: rotate(90deg);
   }
 
   transition: left 0.3s ease-in-out;
 
   &:hover { opacity: 1; }
-  &.open {left: $nav-width}
+  &.open {
+    left: $nav-width-mobile;
+    padding: 100vh 100% 0 0; // click on all area to hide ToC
+    background: rgba(255, 255, 255, .8);
+    backdrop-filter: blur(10px);
+
+    span {
+      background: none;
+      backdrop-filter: none;
+    }
+  }
 }
 
 
@@ -692,16 +617,8 @@ a.link-external:after {
 // There are also a couple styles disperesed
 
 @media (max-width: 1100px) {
-  .site-header {
-    padding: 10px 16px 10px;
-  }
-
-  .site-logo {
-    width: 186px;
-  }
-
   .toc-wrapper {
-    width: 170px;
+    width: $nav-width-mobile;
     padding: 60px 0px 40px;
 
     & > .search input {
@@ -730,6 +647,7 @@ a.link-external:after {
 
     &.open {
       left: 0;
+      box-shadow: 10px 0 10px -6px rgba(0, 0, 0, 0.1);
     }
   }
 


### PR DESCRIPTION
@fremdev there are `/stylesheets/header.css` and `/javascripts/app/_header.js` to be included into other apps. If you think there is a way to move header html from `layout.erb` to separate template and include it everywhere — please advise how to do that.

I've tried to copy it with the css to `/relying-party-registration` и `/token-viewer` via Inspector and it kind of looked good. Let me know if there'll be any bugs.

![nav-demo-320](https://user-images.githubusercontent.com/3016427/91406374-ed9dff00-e84a-11ea-843a-374c681a2767.gif)

